### PR TITLE
SECOPS-2268: Add Gitleaks to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
+  secops: apollo/circleci-secops-orb@2.0.0
 
 jobs:
   build:
@@ -99,3 +100,12 @@ workflows:
     jobs:
       - build:
           context: circleci-user
+  security-scans:
+    jobs:
+      - secops/gitleaks:
+          context:
+            - platform-docker-ro
+            - github-orb
+            - secops-oidc
+          git-base-revision: <<#pipeline.git.base_revision>><<pipeline.git.base_revision>><</pipeline.git.base_revision >>
+          git-revision: << pipeline.git.revision >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
-  secops: apollo/circleci-secops-orb@2.0.0
+  secops: apollo/circleci-secops-orb@2.0.1
 
 jobs:
   build:


### PR DESCRIPTION
## Motivation / Implements

This PR updates `.circleci/config.yml` to configure [Gitleaks](https://github.com/gitleaks/gitleaks) to run on PRs on this repo. The Apollo Security team uses Gitleaks to test our repositories for secrets.

Once this is accepted and merged, the Security team plans to make a passing Gitleaks check a requirement for PRs to merge into this repo. This will prevent secrets from being introduced to our repos.

In the event that a secret _is_ detected on a repo, the CI job will add a comment to the PR associated with the detection to provide instructions on how to properly resolve the detection. Additionally, if a secret is detected, the Apollo Security team will be notified so that we can be available to assist in resolving the detection.

If maintainers reviewing this PR have questions, please see this [Apollo-internal Slack link](https://apollograph.slack.com/archives/C03HCCJBAJC/p1696261536123059).

## Changed

- Updated `.circleci/config.yml` in this repo to contain appropriate configuration to enable Gitleaks as a CI check.
